### PR TITLE
CO-4094 Bump common-orb to 1.19.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  common: syapse/common@1.4.0
+  common: syapse/common@1.19.2
 
 defaults: &defaults
   docker:


### PR DESCRIPTION
Fixes issue relating helm charts with image tags.
